### PR TITLE
Replace `@wrappedtype` with a more comprehensive `@array_aliases`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Derive"
 uuid = "a07dfc7f-7d04-4eb5-84cc-a97f051f655a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ julia> Pkg.add("Derive")
 ## Examples
 
 ````julia
-using Derive: Derive, @derive, @interface, interface
+using Derive: Derive, @array_aliases, @derive, @interface, interface
 using Test: @test
 ````
 
@@ -80,55 +80,64 @@ end
 Define a type that will derive the interface.
 
 ````julia
-struct SparseArrayDOK{T,N} <: AbstractArray{T,N}
+struct SparseDOKArray{T,N} <: AbstractArray{T,N}
   storage::Dict{CartesianIndex{N},T}
   size::NTuple{N,Int}
 end
-storage(a::SparseArrayDOK) = a.storage
-Base.size(a::SparseArrayDOK) = a.size
-function SparseArrayDOK{T}(size::Int...) where {T}
+storage(a::SparseDOKArray) = a.storage
+Base.size(a::SparseDOKArray) = a.size
+function SparseDOKArray{T}(size::Int...) where {T}
   N = length(size)
-  return SparseArrayDOK{T,N}(Dict{CartesianIndex{N},T}(), size)
+  return SparseDOKArray{T,N}(Dict{CartesianIndex{N},T}(), size)
 end
-function isstored(a::SparseArrayDOK, I::Int...)
+function isstored(a::SparseDOKArray, I::Int...)
   return CartesianIndex(I) in keys(storage(a))
 end
-function getstoredindex(a::SparseArrayDOK, I::Int...)
+function getstoredindex(a::SparseDOKArray, I::Int...)
   return storage(a)[CartesianIndex(I)]
 end
-function getunstoredindex(a::SparseArrayDOK, I::Int...)
+function getunstoredindex(a::SparseDOKArray, I::Int...)
   return zero(eltype(a))
 end
-function setstoredindex!(a::SparseArrayDOK, value, I::Int...)
+function setstoredindex!(a::SparseDOKArray, value, I::Int...)
   storage(a)[CartesianIndex(I)] = value
   return a
 end
-function setunstoredindex!(a::SparseArrayDOK, value, I::Int...)
+function setunstoredindex!(a::SparseDOKArray, value, I::Int...)
   storage(a)[CartesianIndex(I)] = value
   return a
 end
 ````
 
-Speficy the interface the type adheres to.
+Specify the interface the type adheres to.
 
 ````julia
-Derive.interface(::Type{<:SparseArrayDOK}) = SparseArrayInterface()
+Derive.interface(::Type{<:SparseDOKArray}) = SparseArrayInterface()
+````
+
+Define aliases like `SparseDOKMatrix`, `AnySparseDOKArray`, etc.
+
+````julia
+@array_aliases SparseDOK
 ````
 
 Derive the interface for the type.
 
 ````julia
-@derive (T=SparseArrayDOK,) begin
+@derive (T=SparseDOKArray,) begin
   Base.getindex(::T, ::Int...)
   Base.setindex!(::T, ::Any, ::Int...)
 end
 
-a = SparseArrayDOK{Float64}(2, 2)
+a = SparseDOKArray{Float64}(2, 2)
 a[1, 1] = 2
 @test a[1, 1] == 2
 @test a[2, 1] == 0
 @test a[1, 2] == 0
 @test a[2, 2] == 0
+
+@test a isa SparseDOKMatrix
+@test a' isa AnySparseDOKMatrix
 ````
 
 Call the sparse array interface on a dense array.

--- a/README.md
+++ b/README.md
@@ -80,30 +80,30 @@ end
 Define a type that will derive the interface.
 
 ````julia
-struct SparseDOKArray{T,N} <: AbstractArray{T,N}
+struct SparseArrayDOK{T,N} <: AbstractArray{T,N}
   storage::Dict{CartesianIndex{N},T}
   size::NTuple{N,Int}
 end
-storage(a::SparseDOKArray) = a.storage
-Base.size(a::SparseDOKArray) = a.size
-function SparseDOKArray{T}(size::Int...) where {T}
+storage(a::SparseArrayDOK) = a.storage
+Base.size(a::SparseArrayDOK) = a.size
+function SparseArrayDOK{T}(size::Int...) where {T}
   N = length(size)
-  return SparseDOKArray{T,N}(Dict{CartesianIndex{N},T}(), size)
+  return SparseArrayDOK{T,N}(Dict{CartesianIndex{N},T}(), size)
 end
-function isstored(a::SparseDOKArray, I::Int...)
+function isstored(a::SparseArrayDOK, I::Int...)
   return CartesianIndex(I) in keys(storage(a))
 end
-function getstoredindex(a::SparseDOKArray, I::Int...)
+function getstoredindex(a::SparseArrayDOK, I::Int...)
   return storage(a)[CartesianIndex(I)]
 end
-function getunstoredindex(a::SparseDOKArray, I::Int...)
+function getunstoredindex(a::SparseArrayDOK, I::Int...)
   return zero(eltype(a))
 end
-function setstoredindex!(a::SparseDOKArray, value, I::Int...)
+function setstoredindex!(a::SparseArrayDOK, value, I::Int...)
   storage(a)[CartesianIndex(I)] = value
   return a
 end
-function setunstoredindex!(a::SparseDOKArray, value, I::Int...)
+function setunstoredindex!(a::SparseArrayDOK, value, I::Int...)
   storage(a)[CartesianIndex(I)] = value
   return a
 end
@@ -112,32 +112,32 @@ end
 Specify the interface the type adheres to.
 
 ````julia
-Derive.interface(::Type{<:SparseDOKArray}) = SparseArrayInterface()
+Derive.interface(::Type{<:SparseArrayDOK}) = SparseArrayInterface()
 ````
 
-Define aliases like `SparseDOKMatrix`, `AnySparseDOKArray`, etc.
+Define aliases like `SparseMatrixDOK`, `AnySparseArrayDOK`, etc.
 
 ````julia
-@array_aliases SparseDOK
+@array_aliases SparseArrayDOK
 ````
 
 Derive the interface for the type.
 
 ````julia
-@derive (T=SparseDOKArray,) begin
+@derive (T=SparseArrayDOK,) begin
   Base.getindex(::T, ::Int...)
   Base.setindex!(::T, ::Any, ::Int...)
 end
 
-a = SparseDOKArray{Float64}(2, 2)
+a = SparseArrayDOK{Float64}(2, 2)
 a[1, 1] = 2
 @test a[1, 1] == 2
 @test a[2, 1] == 0
 @test a[1, 2] == 0
 @test a[2, 2] == 0
 
-@test a isa SparseDOKMatrix
-@test a' isa AnySparseDOKMatrix
+@test a isa SparseMatrixDOK
+@test a' isa AnySparseMatrixDOK
 ````
 
 Call the sparse array interface on a dense array.

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -76,55 +76,55 @@ end
 end
 
 # Define a type that will derive the interface.
-struct SparseDOKArray{T,N} <: AbstractArray{T,N}
+struct SparseArrayDOK{T,N} <: AbstractArray{T,N}
   storage::Dict{CartesianIndex{N},T}
   size::NTuple{N,Int}
 end
-storage(a::SparseDOKArray) = a.storage
-Base.size(a::SparseDOKArray) = a.size
-function SparseDOKArray{T}(size::Int...) where {T}
+storage(a::SparseArrayDOK) = a.storage
+Base.size(a::SparseArrayDOK) = a.size
+function SparseArrayDOK{T}(size::Int...) where {T}
   N = length(size)
-  return SparseDOKArray{T,N}(Dict{CartesianIndex{N},T}(), size)
+  return SparseArrayDOK{T,N}(Dict{CartesianIndex{N},T}(), size)
 end
-function isstored(a::SparseDOKArray, I::Int...)
+function isstored(a::SparseArrayDOK, I::Int...)
   return CartesianIndex(I) in keys(storage(a))
 end
-function getstoredindex(a::SparseDOKArray, I::Int...)
+function getstoredindex(a::SparseArrayDOK, I::Int...)
   return storage(a)[CartesianIndex(I)]
 end
-function getunstoredindex(a::SparseDOKArray, I::Int...)
+function getunstoredindex(a::SparseArrayDOK, I::Int...)
   return zero(eltype(a))
 end
-function setstoredindex!(a::SparseDOKArray, value, I::Int...)
+function setstoredindex!(a::SparseArrayDOK, value, I::Int...)
   storage(a)[CartesianIndex(I)] = value
   return a
 end
-function setunstoredindex!(a::SparseDOKArray, value, I::Int...)
+function setunstoredindex!(a::SparseArrayDOK, value, I::Int...)
   storage(a)[CartesianIndex(I)] = value
   return a
 end
 
 # Specify the interface the type adheres to.
-Derive.interface(::Type{<:SparseDOKArray}) = SparseArrayInterface()
+Derive.interface(::Type{<:SparseArrayDOK}) = SparseArrayInterface()
 
-# Define aliases like `SparseDOKMatrix`, `AnySparseDOKArray`, etc.
-@array_aliases SparseDOK
+# Define aliases like `SparseMatrixDOK`, `AnySparseArrayDOK`, etc.
+@array_aliases SparseArrayDOK
 
 # Derive the interface for the type.
-@derive (T=SparseDOKArray,) begin
+@derive (T=SparseArrayDOK,) begin
   Base.getindex(::T, ::Int...)
   Base.setindex!(::T, ::Any, ::Int...)
 end
 
-a = SparseDOKArray{Float64}(2, 2)
+a = SparseArrayDOK{Float64}(2, 2)
 a[1, 1] = 2
 @test a[1, 1] == 2
 @test a[2, 1] == 0
 @test a[1, 2] == 0
 @test a[2, 2] == 0
 
-@test a isa SparseDOKMatrix
-@test a' isa AnySparseDOKMatrix
+@test a isa SparseMatrixDOK
+@test a' isa AnySparseMatrixDOK
 
 # Call the sparse array interface on a dense array.
 isstored(a::AbstractArray, I::Int...) = true

--- a/src/abstractinterface.jl
+++ b/src/abstractinterface.jl
@@ -8,7 +8,7 @@ interface(::Type) = error("Interface unknown.")
 function combine_interfaces(x1, x2, x_rest...)
   return combine_interfaces(combine_interfaces(x1, x2), x_rest...)
 end
-combine_interfaces(x1, x2) = comine_interface_rule(interface(x1), interface(x2))
+combine_interfaces(x1, x2) = combine_interface_rule(interface(x1), interface(x2))
 combine_interfaces(x) = interface(x)
 
 # Rules for combining interfaces.

--- a/src/wrappedarrays.jl
+++ b/src/wrappedarrays.jl
@@ -1,26 +1,59 @@
-using Adapt: Adapt, WrappedArray
-
-macro array_aliases(type)
-  return esc(array_aliases(type))
+macro vecmat_aliases(type)
+  return esc(vecmat_aliases(type))
 end
 
-function array_aliases(type::Symbol)
+function vecmat_aliases(type::Symbol)
   return quote
     const $(Symbol(type, :Vector)){T} = $(Symbol(type, :Array)){T,1}
     const $(Symbol(type, :Matrix)){T} = $(Symbol(type, :Array)){T,2}
     const $(Symbol(type, :VecOrMat)){T} = Union{
       $(Symbol(type, :Vector)){T},$(Symbol(type, :Matrix)){T}
     }
+  end
+end
+
+using Adapt: Adapt, WrappedArray
+
+macro wrapped_aliases(type)
+  return esc(wrapped_aliases(type))
+end
+
+function wrapped_aliases(type::Symbol)
+  return quote
     const $(Symbol(:Wrapped, type, :Array)){T,N} = $(GlobalRef(Adapt, :WrappedArray)){
       T,N,$(Symbol(type, :Array)),$(Symbol(type, :Array)){T,N}
     }
     const $(Symbol(:Any, type, :Array)){T,N} = Union{
       $(Symbol(type, :Array)){T,N},$(Symbol(:Wrapped, type, :Array)){T,N}
     }
-    const $(Symbol(:Any, type, :Vector)){T} = $(Symbol(:Any, type, :Array)){T,1}
-    const $(Symbol(:Any, type, :Matrix)){T} = $(Symbol(:Any, type, :Array)){T,2}
-    const $(Symbol(:Any, type, :VecOrMat)){T} = Union{
-      $(Symbol(:Any, type, :Vector)){T},$(Symbol(:Any, type, :Matrix)){T}
-    }
   end
+end
+
+macro array_aliases(type)
+  return esc(array_aliases(type))
+end
+
+function array_aliases(type::Symbol)
+  # TODO: I tried to use `quote` here but I couldn't get it to work with `GlobalRef`.
+  return Expr(
+    :block,
+    Expr(
+      :macrocall,
+      :($(GlobalRef(Derive, Symbol("@vecmat_aliases")))),
+      LineNumberNode(0),
+      type,
+    ),
+    Expr(
+      :macrocall,
+      :($(GlobalRef(Derive, Symbol("@wrapped_aliases")))),
+      LineNumberNode(0),
+      type,
+    ),
+    Expr(
+      :macrocall,
+      :($(GlobalRef(Derive, Symbol("@vecmat_aliases")))),
+      LineNumberNode(0),
+      Symbol(:Any, type),
+    ),
+  )
 end

--- a/src/wrappedarrays.jl
+++ b/src/wrappedarrays.jl
@@ -1,14 +1,26 @@
-using Adapt: WrappedArray
+using Adapt: Adapt, WrappedArray
 
-macro wrappedtype(type)
-  return esc(wrappedtype(type))
+macro array_aliases(type)
+  return esc(array_aliases(type))
 end
 
-function wrappedtype(type::Symbol)
-  wrappedtype = Symbol(:Wrapped, type)
-  anytype = Symbol(:Any, type)
+function array_aliases(type::Symbol)
   return quote
-    const $wrappedtype{T,N} = $WrappedArray{T,N,$type,$type{T,N}}
-    const $anytype{T,N} = Union{$type{T,N},$wrappedtype{T,N}}
+    const $(Symbol(type, :Vector)){T} = $(Symbol(type, :Array)){T,1}
+    const $(Symbol(type, :Matrix)){T} = $(Symbol(type, :Array)){T,2}
+    const $(Symbol(type, :VecOrMat)){T} = Union{
+      $(Symbol(type, :Vector)){T},$(Symbol(type, :Matrix)){T}
+    }
+    const $(Symbol(:Wrapped, type, :Array)){T,N} = $(GlobalRef(Adapt, :WrappedArray)){
+      T,N,$(Symbol(type, :Array)),$(Symbol(type, :Array)){T,N}
+    }
+    const $(Symbol(:Any, type, :Array)){T,N} = Union{
+      $(Symbol(type, :Array)){T,N},$(Symbol(:Wrapped, type, :Array)){T,N}
+    }
+    const $(Symbol(:Any, type, :Vector)){T} = $(Symbol(:Any, type, :Array)){T,1}
+    const $(Symbol(:Any, type, :Matrix)){T} = $(Symbol(:Any, type, :Array)){T,2}
+    const $(Symbol(:Any, type, :VecOrMat)){T} = Union{
+      $(Symbol(:Any, type, :Vector)){T},$(Symbol(:Any, type, :Matrix)){T}
+    }
   end
 end


### PR DESCRIPTION
Replace `@wrappedtype` with a more comprehensive `@array_aliases`. For example, `@array_alises SparseArrayDOK` produces type aliases `SparseVectorDOK`, `SparseMatrixDOK`, `AnySparseArrayDOK`, `AnySparseVectorDOK`, etc. while `@wrappedtype` only output the wrapper aliases but not `Vector` or `Matrix` aliases.

It is built out of two other macros `@vecormat_aliases` (to define `SparseVectorDOK`, etc.) and `@wrapped_aliases` (to define `AnySparseArrayDOK`, etc.).