### PR TITLE
Add missing `DefaultArrayInterface` methods

### DIFF
--- a/src/defaultarrayinterface.jl
+++ b/src/defaultarrayinterface.jl
@@ -6,3 +6,27 @@ function interface(a::Type{<:AbstractArray})
   parenttype(a) === a && return DefaultArrayInterface()
   return interface(parenttype(a))
 end
+
+@interface ::DefaultArrayInterface function Base.getindex(
+  a::AbstractArray{<:Any,N}, I::Vararg{Int,N}
+) where {N}
+  return Base.getindex(a, I...)
+end
+
+@interface ::DefaultArrayInterface function Base.setindex!(
+  a::AbstractArray{<:Any,N}, value, I::Vararg{Int,N}
+) where {N}
+  return Base.setindex!(a, value, I...)
+end
+
+@interface ::DefaultArrayInterface function Base.map!(
+  f, a_dest::AbstractArray, a_srcs::AbstractArray...
+)
+  return Base.map!(f, a_dest, a_srcs...)
+end
+
+@interface ::DefaultArrayInterface function Base.mapreduce(
+  f, op, as::AbstractArray...; kwargs...
+)
+  return Base.mapreduce(f, op, as...; kwargs...)
+end


### PR DESCRIPTION
This PR adds some of the methods for `DefaultArrayInterface` that were erroring because there was no `AbstractArrayInterface` fallback.

I'm still not sure if this needs to be implemented with `Base.invoke` or not, but the tests are not complaining?